### PR TITLE
Save table answers with input fields delimited by __. This allows the…

### DIFF
--- a/fpp/Chapters/core/main/js/presentationData.js
+++ b/fpp/Chapters/core/main/js/presentationData.js
@@ -82,7 +82,7 @@ var PresentationData = function(href, lab) {
         for (let r = 0; r < rows; r++) {
             colKeys.forEach((key) => {
                 if (/%VALUE%/.test(table[key][r])) {
-                    table[key][r] = table[key][r].replace(/%VALUE%/, answer[ndx++]);
+                    table[key][r] = table[key][r].replace(/%VALUE%/, '__' + answer[ndx++] + '__');
                 }
             });
         }


### PR DESCRIPTION
… front to distinguish them from hardcoded strings for presentation.